### PR TITLE
Add option to enable or disable sending email on form submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ composer dump-autoload && php artisan voyager-forms:install
 # 3. Configure to/from addresses
         -> Navigate to Admin -> Settings -> 'Forms' tab
         -> Adjust values
+        -> Note: If you leave `Default Enquiry To Email` blank and set no email in the form setting, email will not be sent
         
 # 4. Configure "MAIL" environment variables
 

--- a/config/voyager-forms.php
+++ b/config/voyager-forms.php
@@ -20,4 +20,8 @@ return [
         'radio' => 'Radio',
         'file' => 'File'
     ],
+
+    'email' => [
+        'enabled' => true,
+    ],
 ];

--- a/config/voyager-forms.php
+++ b/config/voyager-forms.php
@@ -20,8 +20,4 @@ return [
         'radio' => 'Radio',
         'file' => 'File'
     ],
-
-    'email' => [
-        'enabled' => true,
-    ],
 ];

--- a/src/Http/Controllers/EnquiryController.php
+++ b/src/Http/Controllers/EnquiryController.php
@@ -72,21 +72,18 @@ class EnquiryController extends VoyagerBaseController
         if (empty($form->mailto)) {
             $form->mailto = !empty(setting('forms.default_to_email'))
                 ? setting('forms.default_to_email')
-                : 'voyager.forms@mailinator.com';
+                : false;
         }
 
-        // setup email if enabled
-        if (config('voyager-forms.email.enabled')) {
-            // The from address
-            $form->mailfrom = !empty(setting('forms.default_from_email'))
-                ? setting('forms.default_from_email')
-                : 'voyager.forms@mailinator.com';
+        // The from address
+        $form->mailfrom = !empty(setting('forms.default_from_email'))
+            ? setting('forms.default_from_email')
+            : 'voyager.forms@mailinator.com';
 
-            // The from name (eg. site address)
-            $form->mailfromname = !empty(setting('site.title'))
-                ? setting('site.title')
-                : 'Website';
-        }
+        // The from name (eg. site address)
+        $form->mailfromname = !empty(setting('site.title'))
+            ? setting('site.title')
+            : 'Website';
 
         // Upload the images files, update $formData to save the image directory and return all the file keys.
 
@@ -103,7 +100,7 @@ class EnquiryController extends VoyagerBaseController
         // return (new EnquiryMailable($form, $formData, $filesKeys))->render();
 
         // Send the email if enabled
-        if (config('voyager-forms.email.enabled')) {
+        if ($form->mailto) {
             Mail::to(array_map('trim', explode(',', $form->mailto)))
                 ->send(new EnquiryMailable($form, $formData, $filesKeys));
         }

--- a/src/Http/Controllers/EnquiryController.php
+++ b/src/Http/Controllers/EnquiryController.php
@@ -75,15 +75,18 @@ class EnquiryController extends VoyagerBaseController
                 : 'voyager.forms@mailinator.com';
         }
 
-        // The from address
-        $form->mailfrom = !empty(setting('forms.default_from_email'))
-            ? setting('forms.default_from_email')
-            : 'voyager.forms@mailinator.com';
+        // setup email if enabled
+        if (config('voyager-forms.email.enabled')) {
+            // The from address
+            $form->mailfrom = !empty(setting('forms.default_from_email'))
+                ? setting('forms.default_from_email')
+                : 'voyager.forms@mailinator.com';
 
-        // The from name (eg. site address)
-        $form->mailfromname = !empty(setting('site.title'))
-            ? setting('site.title')
-            : 'Website';
+            // The from name (eg. site address)
+            $form->mailfromname = !empty(setting('site.title'))
+                ? setting('site.title')
+                : 'Website';
+        }
 
         // Upload the images files, update $formData to save the image directory and return all the file keys.
 
@@ -99,9 +102,11 @@ class EnquiryController extends VoyagerBaseController
         // Debug/Preview the email
         // return (new EnquiryMailable($form, $formData, $filesKeys))->render();
 
-        // Send the email
-        Mail::to(array_map('trim', explode(',', $form->mailto)))
-            ->send(new EnquiryMailable($form, $formData, $filesKeys));
+        // Send the email if enabled
+        if (config('voyager-forms.email.enabled')) {
+            Mail::to(array_map('trim', explode(',', $form->mailto)))
+                ->send(new EnquiryMailable($form, $formData, $filesKeys));
+        }
 
         return redirect()
             ->back()


### PR DESCRIPTION
We needed the custom form builder (which is great) but without the email notification part. So I've added an entry in config/voyager-forms and based on this entry, send or not send the email