### PR TITLE
Update composer for Laravel 8 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "pvtl/voyager-frontend": "^0.9",
+        "pvtl/voyager-frontend": "^1.0.2",
         "tcg/voyager": "^1.1",
         "guzzlehttp/guzzle": "^7.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "pvtl/voyager-frontend": "^0.9",
         "tcg/voyager": "^1.1",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5"


### PR DESCRIPTION
This PR is just a quick and dirty composer file update to allow pvtl/voyager-frontend 1.0 and Guzzle 7.